### PR TITLE
cicd: backport: Fix events allowing the workflow to run

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,28 @@
+name: Backport labeled merged pull requests
+on:
+  pull_request_target:
+    types: [closed]
+jobs:
+  build:
+    name: Create backport PRs
+    runs-on: ubuntu-latest
+    # Only run when pull request is merged
+    # or when a comment containing `/backport` is created
+    if: github.event.pull_request.merged
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Required to find all branches
+          fetch-depth: 0
+      - name: Create backport PRs
+        # Should be kept in sync with `version`
+        uses: zeebe-io/backport-action@v0.0.4
+        with:
+          # Required
+          # Version of the backport-action
+          # Must equal the version in `uses`
+          # Recommended: latest tag or `master`
+          version: v0.0.4
+
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_workspace: ${{ github.workspace }}


### PR DESCRIPTION
Even when using pull_request_target, the merged is issued as
pull_request and this should be used to ensure we can run the workflow.

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>